### PR TITLE
Add AI chat task assistant using Gemini

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -29,9 +29,14 @@ export const routes: Routes = [
     component: TodoListComponent,
     canActivate: [AuthGuard]
   },
-  { 
-    path: 'profile', 
+  {
+    path: 'profile',
     loadComponent: () => import('./components/profile/profile.component').then(m => m.ProfileComponent),
+    canActivate: [AuthGuard]
+  },
+  {
+    path: 'chat',
+    loadComponent: () => import('./components/task-chat/task-chat.component').then(m => m.TaskChatComponent),
     canActivate: [AuthGuard]
   },
   { path: '**', redirectTo: '' }

--- a/src/app/components/task-chat/task-chat.component.ts
+++ b/src/app/components/task-chat/task-chat.component.ts
@@ -1,0 +1,41 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { TaskChatService } from '../../services/task-chat.service';
+
+@Component({
+  selector: 'app-task-chat',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="max-w-xl mx-auto p-4 space-y-4">
+      <div class="h-96 overflow-y-auto border rounded p-3 bg-white dark:bg-gray-800" #scroll>
+        <div *ngFor="let msg of chat.messages$ | async">
+          <div [class.text-right]="msg.role === 'user'">
+            <span class="inline-block px-3 py-2 my-1 rounded-lg"
+                  [ngClass]="msg.role === 'user' ? 'bg-blue-600 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100'">
+              {{ msg.text }}
+            </span>
+          </div>
+        </div>
+      </div>
+      <form class="flex gap-2" (ngSubmit)="send()">
+        <input name="message" [(ngModel)]="input" required
+               class="flex-1 p-2 border rounded" placeholder="Type a message...">
+        <button type="submit" class="btn btn-primary px-4">Send</button>
+      </form>
+    </div>
+  `,
+  styles: []
+})
+export class TaskChatComponent {
+  input = '';
+  constructor(public chat: TaskChatService) {}
+
+  async send() {
+    const text = this.input.trim();
+    if (!text) return;
+    this.input = '';
+    await this.chat.sendMessage(text);
+  }
+}

--- a/src/app/services/task-chat.service.ts
+++ b/src/app/services/task-chat.service.ts
@@ -1,0 +1,105 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { AiAgentService } from './ai-agent.service';
+import { TodoService } from './todo.service';
+
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  text: string;
+}
+
+interface AiAction {
+  type: 'create' | 'update' | 'delete';
+  id?: string;
+  title?: string;
+  description?: string;
+  dueDate?: string;
+  priority?: 'low' | 'medium' | 'high';
+  tags?: string[];
+  completed?: boolean;
+}
+
+interface AiResult {
+  reply?: string;
+  actions?: AiAction[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class TaskChatService {
+  private messagesSubject = new BehaviorSubject<ChatMessage[]>([]);
+  messages$ = this.messagesSubject.asObservable();
+
+  constructor(private ai: AiAgentService, private todos: TodoService) {}
+
+  async sendMessage(text: string): Promise<void> {
+    const messages: ChatMessage[] = [
+      ...this.messagesSubject.value,
+      { role: 'user', text }
+    ];
+    this.messagesSubject.next(messages);
+
+    const prompt = this.buildPrompt(messages);
+    const response = await this.ai.sendPrompt(prompt);
+    if (!response) return;
+
+    const result: AiResult = typeof response === 'string' ? { reply: response } : response;
+    if (result.reply) {
+      messages.push({ role: 'assistant', text: result.reply });
+    }
+    this.messagesSubject.next(messages);
+
+    if (Array.isArray(result.actions)) {
+      for (const action of result.actions) {
+        await this.applyAction(action);
+      }
+    }
+  }
+
+  private buildPrompt(messages: ChatMessage[]): string {
+    const conversation = messages.map(m => `${m.role}: ${m.text}`).join('\n');
+    const system = `You are a task management assistant. When appropriate, respond in JSON like {
+      "reply": "text",
+      "actions": [{
+        "type": "create|update|delete",
+        "id": "optional",
+        "title": "",
+        "description": "",
+        "dueDate": "ISO",
+        "priority": "low|medium|high",
+        "tags": [],
+        "completed": false
+      }]}. Minimize other text.`;
+    return `${system}\n${conversation}`;
+  }
+
+  private async applyAction(action: AiAction): Promise<void> {
+    switch (action.type) {
+      case 'create':
+        await this.todos.addTodo(
+          action.title || 'Untitled',
+          action.description,
+          action.dueDate ? new Date(action.dueDate) : undefined,
+          action.priority || 'medium',
+          action.tags || []
+        );
+        break;
+      case 'update':
+        if (action.id) {
+          await this.todos.updateTodo(action.id, {
+            title: action.title,
+            description: action.description,
+            dueDate: action.dueDate ? new Date(action.dueDate) : undefined,
+            priority: action.priority,
+            tags: action.tags,
+            completed: action.completed
+          });
+        }
+        break;
+      case 'delete':
+        if (action.id) {
+          await this.todos.deleteTodo(action.id);
+        }
+        break;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement `TaskChatService` to chat with Gemini AI and execute task actions
- add `TaskChatComponent` with a simple chat UI
- register a new `/chat` route for the assistant
- fix type errors in `TaskChatService` and simplify system prompt

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad5cccb50832b97c4517e75d4c93f