### PR TITLE
Improve AI assistant to categorize tasks

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -29,9 +29,14 @@ export const routes: Routes = [
     component: TodoListComponent,
     canActivate: [AuthGuard]
   },
-  { 
-    path: 'profile', 
+  {
+    path: 'profile',
     loadComponent: () => import('./components/profile/profile.component').then(m => m.ProfileComponent),
+    canActivate: [AuthGuard]
+  },
+  {
+    path: 'chat',
+    loadComponent: () => import('./components/task-chat/task-chat.component').then(m => m.TaskChatComponent),
     canActivate: [AuthGuard]
   },
   { path: '**', redirectTo: '' }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -35,7 +35,7 @@ export const routes: Routes = [
     canActivate: [AuthGuard]
   },
   {
-    path: 'chat',
+    path: 'app/chat',
     loadComponent: () => import('./components/task-chat/task-chat.component').then(m => m.TaskChatComponent),
     canActivate: [AuthGuard]
   },

--- a/src/app/components/shared/layouts/mobile-layout.component.ts
+++ b/src/app/components/shared/layouts/mobile-layout.component.ts
@@ -42,8 +42,12 @@ import { ThemeToggleComponent } from '../theme-toggle.component';
             <i class="bi bi-plus-lg mobile-nav-icon mb-0"></i>
           </div>
         </a>
-        <a routerLink="/profile" 
-           routerLinkActive="active-nav-item" 
+        <a routerLink="/app/chat" routerLinkActive="active-nav-item" class="mobile-nav-item text-gray-600 dark:text-gray-300">
+          <i class="bi bi-chat-dots mobile-nav-icon"></i>
+          <span class="mobile-nav-text">AI</span>
+        </a>
+        <a routerLink="/profile"
+           routerLinkActive="active-nav-item"
            class="mobile-nav-item text-gray-600 dark:text-gray-300">
           <i class="bi bi-person mobile-nav-icon"></i>
           <span class="mobile-nav-text">Profile</span>

--- a/src/app/components/shared/layouts/tablet-layout.component.ts
+++ b/src/app/components/shared/layouts/tablet-layout.component.ts
@@ -31,6 +31,13 @@ import { CommonModule } from '@angular/common';
               </a>
             </li>
             <li>
+              <a routerLink="/app/chat" routerLinkActive="bg-accent/20 text-accent"
+                 class="flex items-center space-x-3 px-4 py-3 rounded-lg transition-colors">
+                <i class="bi bi-chat-dots text-xl"></i>
+                <span>AI</span>
+              </a>
+            </li>
+            <li>
               <a routerLink="/profile" routerLinkActive="bg-accent/20 text-accent"
                  class="flex items-center space-x-3 px-4 py-3 rounded-lg transition-colors">
                 <i class="bi bi-person text-xl"></i>

--- a/src/app/components/task-chat/task-chat.component.ts
+++ b/src/app/components/task-chat/task-chat.component.ts
@@ -1,0 +1,41 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { TaskChatService } from '../../services/task-chat.service';
+
+@Component({
+  selector: 'app-task-chat',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="max-w-xl mx-auto p-4 space-y-4">
+      <div class="h-96 overflow-y-auto border rounded p-3 bg-white dark:bg-gray-800" #scroll>
+        <div *ngFor="let msg of chat.messages$ | async">
+          <div [class.text-right]="msg.role === 'user'">
+            <span class="inline-block px-3 py-2 my-1 rounded-lg"
+                  [ngClass]="msg.role === 'user' ? 'bg-blue-600 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100'">
+              {{ msg.text }}
+            </span>
+          </div>
+        </div>
+      </div>
+      <form class="flex gap-2" (ngSubmit)="send()">
+        <input name="message" [(ngModel)]="input" required
+               class="flex-1 p-2 border rounded" placeholder="Type a message...">
+        <button type="submit" class="btn btn-primary px-4">Send</button>
+      </form>
+    </div>
+  `,
+  styles: []
+})
+export class TaskChatComponent {
+  input = '';
+  constructor(public chat: TaskChatService) {}
+
+  async send() {
+    const text = this.input.trim();
+    if (!text) return;
+    this.input = '';
+    await this.chat.sendMessage(text);
+  }
+}

--- a/src/app/components/todos/todo-list.component.ts
+++ b/src/app/components/todos/todo-list.component.ts
@@ -171,6 +171,12 @@ const version = '2.0.0';
               <!-- Right side - Theme Toggle & User Info -->
               <div class="flex items-center space-x-4">
                 <app-theme-toggle></app-theme-toggle>
+                <a routerLink="/app/chat" class="inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-lg text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 transition-colors duration-200">
+                  <svg class="w-4 h-4 mr-1.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+                  </svg>
+                  Chat
+                </a>
                 
                 <!-- User Profile -->
                 <div class="flex items-center">
@@ -296,6 +302,12 @@ const version = '2.0.0';
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
                     </svg>
                     <span class="text-sm text-gray-700 dark:text-gray-300">My Notes</span>
+                  </a>
+                  <a routerLink="/app/chat" class="block p-3 bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg transition-all duration-200 flex items-center">
+                    <svg class="w-5 h-5 mr-3 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.418-4.03 8-9 8s-9-3.582-9-8 4.03-8 9-8 9 3.582 9 8z" />
+                    </svg>
+                    <span class="text-sm text-gray-700 dark:text-gray-300">AI Assistant</span>
                   </a>
                 </div>
               </div>

--- a/src/app/services/ai-agent.service.ts
+++ b/src/app/services/ai-agent.service.ts
@@ -57,6 +57,14 @@ export class AiAgentService {
       try {
         return JSON.parse(text);
       } catch (parseError) {
+        const match = text.match(/\{[\s\S]*\}/);
+        if (match) {
+          try {
+            return JSON.parse(match[0]);
+          } catch {
+            /* ignore */
+          }
+        }
         console.warn('Failed to parse AI response as JSON, returning raw text:', parseError);
         return text;
       }

--- a/src/app/services/task-chat.service.ts
+++ b/src/app/services/task-chat.service.ts
@@ -1,0 +1,110 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { AiAgentService } from './ai-agent.service';
+import { TodoService } from './todo.service';
+
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  text: string;
+}
+
+interface AiAction {
+  type: 'create' | 'update' | 'delete' | 'categorize';
+  id?: string;
+  title?: string;
+  description?: string;
+  dueDate?: string;
+  priority?: 'low' | 'medium' | 'high';
+  tags?: string[];
+  completed?: boolean;
+}
+
+interface AiResult {
+  reply?: string;
+  actions?: AiAction[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class TaskChatService {
+  private messagesSubject = new BehaviorSubject<ChatMessage[]>([]);
+  messages$ = this.messagesSubject.asObservable();
+
+  constructor(private ai: AiAgentService, private todos: TodoService) {}
+
+  async sendMessage(text: string): Promise<void> {
+    const messages: ChatMessage[] = [
+      ...this.messagesSubject.value,
+      { role: 'user', text }
+    ];
+    this.messagesSubject.next(messages);
+
+    const prompt = this.buildPrompt(messages);
+    const response = await this.ai.sendPrompt(prompt);
+    if (!response) return;
+
+    const result: AiResult = typeof response === 'string' ? { reply: response } : response;
+    if (result.reply) {
+      messages.push({ role: 'assistant', text: result.reply });
+    }
+    this.messagesSubject.next(messages);
+
+    if (Array.isArray(result.actions)) {
+      for (const action of result.actions) {
+        await this.applyAction(action);
+      }
+    }
+  }
+
+  private buildPrompt(messages: ChatMessage[]): string {
+    const conversation = messages.map(m => `${m.role}: ${m.text}`).join('\n');
+    const system = `You are a task management assistant. When appropriate, respond in JSON like {
+      "reply": "text",
+      "actions": [{
+        "type": "create|update|delete|categorize",
+        "id": "optional",
+        "title": "",
+        "description": "",
+        "dueDate": "ISO",
+        "priority": "low|medium|high",
+        "tags": [],
+        "completed": false
+      }]}. Minimize other text.`;
+    return `${system}\n${conversation}`;
+  }
+
+  private async applyAction(action: AiAction): Promise<void> {
+    switch (action.type) {
+      case 'create':
+        await this.todos.addTodo(
+          action.title || 'Untitled',
+          action.description,
+          action.dueDate ? new Date(action.dueDate) : undefined,
+          action.priority || 'medium',
+          action.tags || []
+        );
+        break;
+      case 'update':
+        if (action.id) {
+          await this.todos.updateTodo(action.id, {
+            title: action.title,
+            description: action.description,
+            dueDate: action.dueDate ? new Date(action.dueDate) : undefined,
+            priority: action.priority,
+            tags: action.tags,
+            completed: action.completed
+          });
+        }
+        break;
+      case 'delete':
+        if (action.id) {
+          await this.todos.deleteTodo(action.id);
+        }
+        break;
+      case 'categorize':
+        if (action.id && action.tags) {
+          await this.todos.updateTodo(action.id, { tags: action.tags });
+        }
+        break;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- extend `AiAction` with new `categorize` type
- update prompt to include `categorize` action
- apply categorize actions by updating todo tags

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad5cccb50832b97c4517e75d4c93f