### PR TITLE
Implement new color palette and drop Facebook auth

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -340,9 +340,6 @@
             <a href="#" class="text-gray-400 hover:text-white transition-colors" aria-label="Twitter">
               <i class="bi bi-twitter"></i>
             </a>
-            <a href="#" class="text-gray-400 hover:text-white transition-colors" aria-label="Facebook">
-              <i class="bi bi-facebook"></i>
-            </a>
             <a href="#" class="text-gray-400 hover:text-white transition-colors" aria-label="Instagram">
               <i class="bi bi-instagram"></i>
             </a>

--- a/src/app/components/auth/login.component.ts
+++ b/src/app/components/auth/login.component.ts
@@ -133,7 +133,7 @@ import { AlertService } from '../../services/alert.service';
               </div>
             </div>
 
-            <div class="mt-6 grid grid-cols-2 gap-4">
+            <div class="mt-6 grid grid-cols-1 gap-4">
               <button 
                 type="button" 
                 (click)="loginWithGoogle()"
@@ -147,15 +147,6 @@ import { AlertService } from '../../services/alert.service';
                 Google
               </button>
               
-              <button 
-                type="button"
-                (click)="loginWithFacebook()"
-                class="w-full inline-flex justify-center items-center py-2.5 px-4 border border-gray-300 rounded-xl shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.98]">
-                <svg class="w-5 h-5 mr-2 text-[#1877F2]" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
-                </svg>
-                Facebook
-              </button>
             </div>
           </div>
         </div>
@@ -227,19 +218,4 @@ export class LoginComponent {
       });
   }
 
-  loginWithFacebook() {
-    this.isLoading = true;
-    this.authService.facebookLogin()
-      .then(() => {
-        this.alertService.addAlert('Login with Facebook successful!', 'success');
-        this.router.navigate(['/app']);
-      })
-      .catch(error => {
-        console.error('Facebook login error:', error);
-        this.alertService.addAlert('Facebook login failed: ' + error.message, 'error');
-      })
-      .finally(() => {
-        this.isLoading = false;
-      });
-  }
 } 

--- a/src/app/components/shared/footer/footer.component.ts
+++ b/src/app/components/shared/footer/footer.component.ts
@@ -25,12 +25,6 @@ export class FooterComponent implements OnInit, OnDestroy {
 
   socialLinks = [
     {
-      id: 'facebook',
-      name: 'Facebook',
-      url: 'https://www.facebook.com/ashan.senadheera.2025',
-      icon: 'bi bi-facebook'
-    },
-    {
       id: 'website',
       name: 'Website',
       url: 'http://ashansenadheera.lk',

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -487,9 +487,4 @@ export class AuthService {
     return this.login('demo@example.com', 'password');  
   }  
   
-  // Facebook Login   
-  facebookLogin(): Promise<any> {    
-    // Implement Facebook authentication or modify this if already implemented    
-    return this.login('demo@example.com', 'password');  
-  }
 } 

--- a/src/styles.css
+++ b/src/styles.css
@@ -154,7 +154,12 @@
     --scrollbar-track: transparent;
     --scrollbar-thumb: #d1d5db;
     --transition-ease: all 0.3s ease;
-    --accent-color: #3b82f6;
+    --color-blue: #1d4ed8;
+    --color-black: #000000;
+    --color-green: #16a34a;
+    --color-yellow: #facc15;
+    --color-red: #ef4444;
+    --accent-color: var(--color-blue);
     --accent-hover: #2563eb;
     --card-bg: #ffffff;
     --card-border: #e2e8f0;
@@ -164,8 +169,13 @@
 
   .dark {
     --scrollbar-thumb: #4b5563;
-    --accent-color: #3b82f6;
-    --accent-hover: #60a5fa;
+    --color-blue: #60a5fa;
+    --color-black: #000000;
+    --color-green: #22c55e;
+    --color-yellow: #facc15;
+    --color-red: #ef4444;
+    --accent-color: var(--color-blue);
+    --accent-hover: #93c5fd;
     --card-bg: #1e293b;
     --card-border: #334155;
     --text-primary: #f3f4f6;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,13 @@ module.exports = {
     extend: {
       colors: {
         primary: '#2563eb', // Changed to Blue-600 for better contrast
+        base: {
+          blue: '#1d4ed8',
+          black: '#000000',
+          green: '#16a34a',
+          yellow: '#facc15',
+          red: '#ef4444'
+        },
         accent: {
           DEFAULT: '#3b82f6',
           light: '#60a5fa',


### PR DESCRIPTION
## Summary
- refresh CSS color variables using blue, black, green, yellow and red
- expose new base colors in Tailwind config
- remove Facebook login option
- drop Facebook social link

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ffec6ffe8832bae1bb14c8a7924f0