### PR TITLE
Refresh theme with violet palette

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -44,13 +44,13 @@ import { DeviceService } from './services/device.service';
       display: block;
       width: 100%;
       height: 100%;
-      --primary: #4361ee;
-      --primary-dark: #3a56d4;
-      --primary-light: #4895ef;
-      --secondary: #560bad;
-      --accent: #f72585;
-      --success: #06d6a0;
-      --warning: #ffd166;
+      --primary: #8b5cf6;
+      --primary-dark: #6d28d9;
+      --primary-light: #c084fc;
+      --secondary: #9333ea;
+      --accent: #ec4899;
+      --success: #22c55e;
+      --warning: #eab308;
       --danger: #ef476f;
       --neutral-50: #f8fafc;
       --neutral-100: #f1f5f9;
@@ -64,20 +64,20 @@ import { DeviceService } from './services/device.service';
       --neutral-900: #0f172a;
       --neutral-950: #020617;
       
-      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      font-family: 'Jost', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
       color: var(--neutral-800);
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
     }
     
     ::ng-deep :root {
-      --primary: #4361ee;
-      --primary-dark: #3a56d4;
-      --primary-light: #4895ef;
-      --secondary: #560bad;
-      --accent: #f72585;
-      --success: #06d6a0;
-      --warning: #ffd166;
+      --primary: #8b5cf6;
+      --primary-dark: #6d28d9;
+      --primary-light: #c084fc;
+      --secondary: #9333ea;
+      --accent: #ec4899;
+      --success: #22c55e;
+      --warning: #eab308;
       --danger: #ef476f;
       --neutral-50: #f8fafc;
       --neutral-100: #f1f5f9;
@@ -98,7 +98,7 @@ import { DeviceService } from './services/device.service';
       margin: 0;
       padding: 0;
       line-height: 1.5;
-      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      font-family: 'Jost', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
     }
     
     ::ng-deep body.dark-mode {

--- a/src/app/components/landing/landing.component.ts
+++ b/src/app/components/landing/landing.component.ts
@@ -41,12 +41,12 @@ import { ThemeToggleComponent } from '../shared/theme-toggle.component';
           <div class="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
             <div>
               <h1 class="text-4xl md:text-5xl font-bold font-display text-gray-800 dark:text-white leading-tight mb-6">
-                Your Tasks, <br>
-                <span class="text-primary dark:text-primary-light">Organized & Simplified</span>
+                Streamline Your Workflow<br>
+                <span class="text-primary dark:text-primary-light">with MyTasks</span>
               </h1>
               <p class="text-lg md:text-xl text-gray-600 dark:text-gray-300 mb-8 max-w-lg">
-                Boost your productivity with our intuitive task management platform. 
-                Stay organized, focused, and accomplish more every day.
+                Manage projects effortlessly with an interface crafted for clarity.
+                Focus on what matters and achieve more every single day.
               </p>
               <div class="flex flex-col sm:flex-row gap-4 mb-8">
                 <a routerLink="/register" class="btn btn-primary btn-lg">

--- a/src/index.html
+++ b/src/index.html
@@ -39,8 +39,8 @@
   <!-- ✅ Performance Optimizations -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <!-- Inter Font -->
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+  <!-- Jost Font for modern look -->
+  <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   
   <!-- ✅ Favicon -->
   <link rel="icon" type="image/png" sizes="32x32" href="favicon.png">

--- a/src/styles.css
+++ b/src/styles.css
@@ -65,13 +65,13 @@
 
 /* Hero Section Styles */
 .mobile-hero, .tablet-hero {
-  background: linear-gradient(135deg, #1d4ed8, #3b82f6, #60a5fa);
+  background: linear-gradient(135deg, #8b5cf6, #ec4899, #f472b6);
   position: relative;
   overflow: hidden;
 }
 
 .hero-blob {
-  background: radial-gradient(circle at 70% 20%, rgba(96, 165, 250, 0.7), rgba(37, 99, 235, 0.2) 60%);
+  background: radial-gradient(circle at 70% 20%, rgba(236, 72, 153, 0.7), rgba(139, 92, 246, 0.2) 60%);
   animation: blob-float 20s ease-in-out infinite alternate;
 }
 
@@ -162,13 +162,13 @@
     --scrollbar-track: transparent;
     --scrollbar-thumb: #d1d5db;
     --transition-ease: all 0.2s ease;
-    --color-blue: #1d4ed8;
+    --color-blue: #8b5cf6;
     --color-black: #111827;
-    --color-green: #16a34a;
-    --color-yellow: #facc15;
+    --color-green: #22c55e;
+    --color-yellow: #eab308;
     --color-red: #ef4444;
-    --accent-color: var(--color-blue);
-    --accent-hover: #2563eb;
+    --accent-color: #ec4899;
+    --accent-hover: #db2777;
     --card-bg: #ffffff;
     --card-border: #e2e8f0;
     --text-primary: #1f2937;
@@ -177,13 +177,13 @@
 
   .dark {
     --scrollbar-thumb: #4b5563;
-    --color-blue: #3b82f6;
+    --color-blue: #c084fc;
     --color-black: #111827;
     --color-green: #22c55e;
     --color-yellow: #fbbf24;
     --color-red: #f87171;
-    --accent-color: var(--color-blue);
-    --accent-hover: #60a5fa;
+    --accent-color: #f472b6;
+    --accent-hover: #fb7185;
     --card-bg: #1e293b;
     --card-border: #334155;
     --text-primary: #f9fafb;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,21 +8,21 @@ module.exports = {
     extend: {
       colors: {
         primary: {
-          DEFAULT: '#1d4ed8', // Blue-700
-          light: '#3b82f6',   // Blue-500
-          dark: '#1e40af'     // Blue-800
+          DEFAULT: '#8b5cf6', // Violet-500
+          light: '#c084fc',   // Violet-300
+          dark: '#6d28d9'     // Violet-700
         },
         base: {
-          blue: '#1d4ed8',    // Blue-700
+          blue: '#8b5cf6',    // Violet-500
           black: '#111827',   // Gray-900
-          green: '#16a34a',   // Green-600
-          yellow: '#facc15',  // Yellow-400
+          green: '#22c55e',   // Green-500
+          yellow: '#eab308',  // Yellow-500
           red: '#ef4444'      // Red-500
         },
         accent: {
-          DEFAULT: '#3b82f6', // Blue-500
-          light: '#60a5fa',   // Blue-400
-          dark: '#1d4ed8'     // Blue-700
+          DEFAULT: '#ec4899', // Fuchsia-500
+          light: '#f472b6',   // Fuchsia-300
+          dark: '#be185d'     // Rose-700
         },
         background: {
           DEFAULT: '#f8fafc',           // Slate-50
@@ -56,8 +56,8 @@ module.exports = {
         }
       },
       fontFamily: {
-        'sans': ['Space Grotesk', 'ui-sans-serif', 'system-ui', 'sans-serif'],
-        'display': ['Orbitron', 'Space Grotesk', 'ui-sans-serif', 'system-ui', 'sans-serif']
+        'sans': ['Jost', 'Space Grotesk', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        'display': ['Orbitron', 'Jost', 'ui-sans-serif', 'system-ui', 'sans-serif']
       },
       boxShadow: {
         'card': '0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.02)',


### PR DESCRIPTION
## Summary
- modernize font using Jost and update tailwind font stacks
- switch primary/accent colors to a violet/fuchsia theme
- tweak CSS variables and hero gradients
- update landing page copy for a refreshed feel

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685145adc7a0832b93fa48398a48f6b9