### PR TITLE
Fix Firestore writeBatch import

### DIFF
--- a/src/app/services/chat-firestore.service.ts
+++ b/src/app/services/chat-firestore.service.ts
@@ -1,18 +1,20 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { 
-  Firestore, 
-  collection, 
-  addDoc, 
-  query, 
-  where, 
-  orderBy, 
-  onSnapshot, 
-  serverTimestamp, 
-  Timestamp, 
-  getDocs, 
+import {
+  Firestore,
+  collection,
+  addDoc,
+  query,
+  where,
+  orderBy,
+  onSnapshot,
+  serverTimestamp,
+  Timestamp,
+  getDocs,
   deleteDoc,
   limit,
-  DocumentData
+  DocumentData,
+  writeBatch,
+  updateDoc
 } from 'firebase/firestore';
 import { BehaviorSubject, Observable, Subscription, interval } from 'rxjs';
 import { AuthService } from './auth.service';
@@ -340,5 +342,3 @@ export class ChatFirestoreService implements OnDestroy {
   }
 }
 
-// Helper imports
-import { writeBatch, updateDoc } from 'firebase/firestore'; 


### PR DESCRIPTION
## Summary
- import `writeBatch` and `updateDoc` at top of ChatFirestoreService
- remove leftover import at file end

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515a2f72a4832bb1166fa2711d7427