### PR TITLE
Fix auth redirect and add looped chat actions

### DIFF
--- a/src/app/components/chat-interface/chat-interface.component.ts
+++ b/src/app/components/chat-interface/chat-interface.component.ts
@@ -133,20 +133,22 @@ export class ChatInterfaceComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    // Check if user is authenticated
-    this.subscriptions.add(
-      this.chatService.auth.user$.subscribe(user => {
-        if (!user) {
-          // Only redirect if we're not already on the login page
-          if (!window.location.pathname.includes('/login')) {
-            this.handleAuthError();
+    // Wait for auth initialization before checking user state
+    this.chatService.auth.authReady.then(() => {
+      this.subscriptions.add(
+        this.chatService.auth.user$.subscribe(user => {
+          if (!user) {
+            // Only redirect if we're not already on the login page
+            if (!window.location.pathname.includes('/login')) {
+              this.handleAuthError();
+            }
+          } else {
+            // User is authenticated, load their data
+            this.loadUserData();
           }
-        } else {
-          // User is authenticated, load their data
-          this.loadUserData();
-        }
-      })
-    );
+        })
+      );
+    });
     
     // Check screen size to determine if sidebar should be open by default
     this.isSidebarOpen.set(window.innerWidth >= 1024);

--- a/src/app/components/chat-interface/chat-sidebar.component.ts
+++ b/src/app/components/chat-interface/chat-sidebar.component.ts
@@ -65,22 +65,17 @@ import { Conversation } from '../../services/chat-firestore.service';
                   {{ convo.lastMessage }}
                 </p>
               </div>
-              <!-- Action buttons -->
+              <!-- Action buttons generated via loop -->
               <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                <button 
-                  (click)="startEdit(convo)"
-                  class="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-500 dark:text-gray-400"
-                  title="Rename conversation"
-                >
-                  <i class="bi bi-pencil text-sm"></i>
-                </button>
-                <button 
-                  (click)="onDeleteConversation(convo.id)"
-                  class="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-500 dark:text-gray-400"
-                  title="Delete conversation"
-                >
-                  <i class="bi bi-trash text-sm"></i>
-                </button>
+                <ng-container *ngFor="let action of actionButtons">
+                  <button
+                    (click)="action.action(convo)"
+                    class="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-500 dark:text-gray-400"
+                    [title]="action.title"
+                  >
+                    <i class="bi text-sm" [ngClass]="action.icon"></i>
+                  </button>
+                </ng-container>
               </div>
             </div>
           </div>
@@ -126,6 +121,20 @@ export class ChatSidebarComponent {
   
   editingConversation: string | null = null;
   editTitle: string = '';
+
+  // Actions used for generating buttons via a loop
+  actionButtons = [
+    {
+      icon: 'bi-pencil',
+      title: 'Rename conversation',
+      action: (c: Conversation) => this.startEdit(c)
+    },
+    {
+      icon: 'bi-trash',
+      title: 'Delete conversation',
+      action: (c: Conversation) => this.onDeleteConversation(c.id)
+    }
+  ];
   
   onSelectConversation(id: string): void {
     this.conversationSelected.emit(id);


### PR DESCRIPTION
## Summary
- wait for authReady before checking user in chat interface
- generate conversation rename/delete buttons via a loop

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516d78bb6c832bae55685997053e52