### PR TITLE
Add AI chat assistant with DeepSeek API

### DIFF
--- a/src/app/app.config.browser.ts
+++ b/src/app/app.config.browser.ts
@@ -4,12 +4,14 @@ import { routes } from './app.routes';
 import { provideClientHydration } from '@angular/platform-browser';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { AppModule } from './app.module';
+import { provideHttpClient } from '@angular/common/http';
 
 export const browserConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes),
     provideClientHydration(),
     provideAnimations(),
+    provideHttpClient(),
     importProvidersFrom(AppModule)
   ]
-}; 
+};

--- a/src/app/app.config.server.ts
+++ b/src/app/app.config.server.ts
@@ -1,10 +1,12 @@
 import { ApplicationConfig, mergeApplicationConfig } from '@angular/core';
 import { provideServerRendering } from '@angular/platform-server';
+import { provideHttpClient } from '@angular/common/http';
 import { browserConfig } from './app.config.browser';
 
 const serverConfig: ApplicationConfig = {
   providers: [
-    provideServerRendering()
+    provideServerRendering(),
+    provideHttpClient()
   ]
 };
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -24,13 +24,18 @@ export const routes: Routes = [
     component: TodoListComponent,
     canActivate: [AuthGuard]
   },
-  { 
-    path: 'app', 
+  {
+    path: 'app',
     component: TodoListComponent,
     canActivate: [AuthGuard]
   },
-  { 
-    path: 'profile', 
+  {
+    path: 'app/aiassistant',
+    loadComponent: () => import('./components/aiassistant/ai-assistant.component').then(m => m.AiAssistantComponent),
+    canActivate: [AuthGuard]
+  },
+  {
+    path: 'profile',
     loadComponent: () => import('./components/profile/profile.component').then(m => m.ProfileComponent),
     canActivate: [AuthGuard]
   },

--- a/src/app/components/aiassistant/ai-assistant.component.ts
+++ b/src/app/components/aiassistant/ai-assistant.component.ts
@@ -1,0 +1,46 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { AiChatService, ChatMessage } from '../../services/ai-chat.service';
+
+@Component({
+  selector: 'app-ai-assistant',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="min-h-screen flex flex-col p-4">
+      <div class="flex-1 overflow-auto mb-4 space-y-2">
+        <div *ngFor="let msg of messages">
+          <div [class.text-right]="msg.role === 'user'">
+            <span [ngClass]="msg.role === 'user' ? 'bg-blue-500 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100'" class="rounded p-2 inline-block max-w-full break-words">
+              {{ msg.content }}
+            </span>
+          </div>
+        </div>
+      </div>
+      <form (ngSubmit)="send()" class="flex space-x-2">
+        <input name="input" [(ngModel)]="input" required placeholder="Ask the assistant..." class="flex-1 border rounded px-2 py-1 dark:bg-gray-700 dark:text-white" />
+        <button type="submit" class="px-4 py-1 rounded bg-primary text-white">Send</button>
+      </form>
+    </div>
+  `
+})
+export class AiAssistantComponent {
+  messages: ChatMessage[] = [];
+  input = '';
+
+  constructor(private chat: AiChatService) {}
+
+  send() {
+    const content = this.input.trim();
+    if (!content) return;
+    this.messages.push({ role: 'user', content });
+    this.input = '';
+    this.chat.send(this.messages).subscribe(res => {
+      const reply = res?.choices?.[0]?.message?.content || '';
+      if (reply) {
+        this.messages.push({ role: 'assistant', content: reply });
+      }
+    });
+  }
+}

--- a/src/app/services/ai-chat.service.ts
+++ b/src/app/services/ai-chat.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { Observable } from 'rxjs';
+
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AiChatService {
+  private endpoint = 'https://api.deepseek.com/chat/completions';
+  private apiKey = environment.deepSeekApiKey;
+
+  constructor(private http: HttpClient) {}
+
+  send(messages: ChatMessage[]): Observable<any> {
+    const headers = new HttpHeaders({
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${this.apiKey}`
+    });
+    const body = { model: 'deepseek-chat', messages };
+    return this.http.post<any>(this.endpoint, body, { headers });
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -8,5 +8,6 @@ export const environment = {
     messagingSenderId: process.env['FIREBASE_MESSAGING_SENDER_ID'] || "456710557347",
     appId: process.env['FIREBASE_APP_ID'] || "1:456710557347:web:d2a069bcbe4a1fb9ab3916",
     measurementId: process.env['FIREBASE_MEASUREMENT_ID'] || "G-MLK1HF1MTG"
-  }
-}; 
+  },
+  deepSeekApiKey: process.env['DEEPSEEK_API_KEY'] || "sk-33bd1b357d514a3d8134cc17ab602b70"
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -8,5 +8,6 @@ export const environment = {
     messagingSenderId: "456710557347",
     appId: "1:456710557347:web:d2a069bcbe4a1fb9ab3916",
     measurementId: "G-MLK1HF1MTG"
-  }
-}; 
+  },
+  deepSeekApiKey: "sk-33bd1b357d514a3d8134cc17ab602b70"
+};


### PR DESCRIPTION
## Summary
- include DeepSeek key in environments
- set up `AiChatService` for DeepSeek API
- add `AiAssistantComponent` for chat interface
- configure `/app/aiassistant` route
- provide HttpClient in app configs

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68529f377cb8832bb7a842e90c5f6885